### PR TITLE
Scroll example

### DIFF
--- a/examples/turbolinks/index.html
+++ b/examples/turbolinks/index.html
@@ -23,7 +23,7 @@
       Default <a href="foo.html">Foo</a>
   </div>
   <div>
-     Default <a href="sub/page.html">Page</a>
+     Default <a href="sub/page.html#bottom">Page</a>
   </div>
   <script src="body.js"></script>
 </body>

--- a/examples/turbolinks/sub/page.html
+++ b/examples/turbolinks/sub/page.html
@@ -12,8 +12,9 @@
   <div>
       Page <a href="../foo.html">Foo</a>
   </div>
-  <div>
+  <div style="height: 1000px;">
      Page <a href="../index.html">Bar</a>
   </div>
+  <a id="bottom" style="position: absolute;top:1000px;" href="#test">Botton</a>
 </body>
 </html>


### PR DESCRIPTION
@jbalsas, if you go to the turbolinks example and click on the last link `Default Page`, you will notice the scroll doesn't go to the bottom of the page. If you then merge this branch with the fix I sent in https://github.com/liferay/senna.js/pull/195, that should work.